### PR TITLE
feat: Release the GIL when decoding the image

### DIFF
--- a/src/wuffs-aux-image-wrapper.h
+++ b/src/wuffs-aux-image-wrapper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pybind11/numpy.h>
+#include <Python.h>
 
 #include <map>
 #include <string>
@@ -343,16 +344,20 @@ class ImageDecoder : public wuffs_aux::DecodeImageCallbacks {
   }
 
   ImageDecodingResult DecodeInternal(wuffs_aux::sync_io::Input& input) {
-    wuffs_aux::DecodeImageResult decode_image_result = wuffs_aux::DecodeImage(
-        *this, input, quirks_, flags_, pixel_blend_, background_color_,
-        max_incl_dimension_, max_incl_metadata_length_);
-    decoding_result_.error_message =
-        std::move(decode_image_result.error_message);
-    if (!decode_image_result.pixbuf.pixcfg.is_valid()) {
+    std::unique_ptr<wuffs_aux::DecodeImageResult> decode_image_result;
+
+    Py_BEGIN_ALLOW_THREADS;
+    decode_image_result = std::make_unique<wuffs_aux::DecodeImageResult>(
+        wuffs_aux::DecodeImage(
+            *this, input, quirks_, flags_, pixel_blend_, background_color_,
+            max_incl_dimension_, max_incl_metadata_length_));
+    Py_END_ALLOW_THREADS;
+    decoding_result_.error_message = std::move(decode_image_result->error_message);
+    if (!decode_image_result->pixbuf.pixcfg.is_valid()) {
       decoding_result_.pixbuf = {};
       decoding_result_.pixcfg = wuffs_base__null_pixel_config();
     } else {
-      decoding_result_.pixcfg = decode_image_result.pixbuf.pixcfg;
+      decoding_result_.pixcfg = decode_image_result->pixbuf.pixcfg;
       decoding_result_.pixbuf =
           decoding_result_.pixbuf.reshape(std::vector<size_t>{
               decoding_result_.pixcfg.height(), decoding_result_.pixcfg.width(),


### PR DESCRIPTION
Hey there, firstly, thanks a heap for making this package. It's been great for us as we try and optimize some of our image loading workflows. We work with really large images so being able to load them in quicker is a blessing.

Though upon some testing I discovered that this package isn't so great for loading in multiple images at the same time via the use of threads, actually, it performs significantly worse than opencv. Most python image libraries which make use of C-extensions seem to release the GIL at some point to improve multi-threaded performance.

So I've added some handling here to release the GIL, and it works. But I'm not sure if this is the best solution / there may be a more optimal place to do it as I believe there are still some areas for optimization.  Also just FYI, I'm not that experienced with writing python-C binding code, this are really my first crack at it.

Even after these changes, it is only on-par with opencv in terms of multi-threaded performance, whereas it still beats it in single threaded performance, so I reckon there are still areas for improvement.

Let me know what you think, if this change is even desired and if there may be some more optimizations we can do!  I've added some timings and a test script below:

# Benchmarks, using a 15k RGBA image (15000,13000)

|                 | OpenCV | PyWuffs (current) | PyWuffs (proposed) |
| --------------- | ------ | ----------------- | ------------------ |
| Single Threaded | 1.83s  | 1.01s             | 1.01s              |
| 3 Concurrent Threads       | 2.02s  | 3.00s             | 1.44s              |
| 6 Concurrent Threads       | 2.40s  | 6.01s             | 2.21s              |
| 18 Concurrent Threads      | 5.56s  | 17.44s            | 5.88s              |

```python
from concurrent.futures import ThreadPoolExecutor
import time
import cv2
import numpy as np
from pywuffs import ImageDecoderType, PixelFormat
from pywuffs.aux import ImageDecoder, ImageDecoderConfig


def load_wuffs(filepath: str) -> np.ndarray:
    """
    Returns numpy array from .png encoding.

    :param filename: filename to .png file.
    :param pixel_format: pixel format to decode image as; see PixelFormatType class.
    :return: image array
    """
    t = time.time()

    config = ImageDecoderConfig()
    config.enabled_decoders = [ImageDecoderType.PNG]
    config.pixel_format = PixelFormat.BGRA_NONPREMUL

    decoder = ImageDecoder(config)
    decoding_result = decoder.decode(filepath)
    image_data = decoding_result.pixbuf

    return time.time() - t


def load_cv2(filepath: str) -> np.ndarray:
    t = time.time()
    image = cv2.imread(filepath)
    return time.time() - t


if __name__ == "__main__":
    max_workers = 6
    thread_executor = ThreadPoolExecutor(max_workers=max_workers)
    image_path = "image.png"

    t = time.time()
    image = load_wuffs(image_path)
    print("Wuffs Single Thread Time: ", time.time() - t)

    t = time.time()
    image = load_cv2(image_path)
    print("OpenCV Single Thread Time: ", time.time() - t)

    futures = []
    t = time.time()
    for i in range(max_workers):
        futures.append(thread_executor.submit(load_wuffs, image_path))

    avg_time = sum([future.result() for future in futures]) / max_workers
    print("Wuffs Multi Thread Total Time: ", time.time() - t)
    print("Wuffs Multi Thread Avg Time: ", avg_time)

    futures = []
    t = time.time()
    for i in range(max_workers):
        futures.append(thread_executor.submit(load_cv2, image_path))

    avg_time = sum([future.result() for future in futures]) / max_workers
    print("OpenCV Multi Thread Total Time: ", time.time() - t)
    print("OpenCV Multi Thread Avg Time: ", avg_time)

```
